### PR TITLE
chore: add checksum for the rootfs.tar.xz generated file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,6 +86,7 @@ build_task:
     tar rf rootfs.tar --mode=644 --group=root --owner=root etc/resolv.conf
     echo "Compressing rootfs.tar.."
     xz --verbose rootfs.tar
+    shasum -a 256 rootfs.tar.xz > shasums
     echo "Done"
     ls -l rootfs.tar.xz
   release_script: |
@@ -106,5 +107,5 @@ build_task:
     echo "Releasing $NEXT_RELEASE"
     set -o verbose
     gh release create $NEXT_RELEASE -d -F changes
-    gh release upload $NEXT_RELEASE lastimage rootfs.tar.xz version
+    gh release upload $NEXT_RELEASE lastimage rootfs.tar.xz shasums version
     gh release edit $NEXT_RELEASE --draft=false


### PR DESCRIPTION
In order to embed the file in Podman Desktop, it'll nice to be able to verify the checksum of the downloaded file

I used the same format/pattern than on podman repository

example:
https://github.com/containers/podman/releases/download/v4.3.1/shasums

Change-Id: Ifc0bd51500fc1d89e6b0c89ad00d0b0eaaa581ee
Signed-off-by: Florent Benoit <fbenoit@redhat.com>